### PR TITLE
feat: generic reward pool

### DIFF
--- a/veLords/Scarb.lock
+++ b/veLords/Scarb.lock
@@ -16,5 +16,5 @@ source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.10.0#d7
 
 [[package]]
 name = "snforge_std"
-version = "0.23.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.23.0#f2bff8f796763ada77fe6033ec1b034ceee22abd"
+version = "0.20.0"
+source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.20.0#423eecf7847469e353258321274394b9155d24eb"

--- a/veLords/src/interfaces/IRewardPool.cairo
+++ b/veLords/src/interfaces/IRewardPool.cairo
@@ -1,13 +1,14 @@
 use starknet::ContractAddress;
 
 #[starknet::interface]
-pub trait IDLordsRewardPool<TContractState> {
+pub trait IRewardPool<TContractState> {
     // TODO: docs
 
     //
     // getters
     //
 
+    fn get_reward_token(self: @TContractState) -> ContractAddress;
     fn get_start_time(self: @TContractState) -> u64;
     fn get_time_cursor(self: @TContractState) -> u64;
     fn get_time_cursor_of(self: @TContractState, account: ContractAddress) -> u64;

--- a/veLords/src/lib.cairo
+++ b/veLords/src/lib.cairo
@@ -1,10 +1,10 @@
 mod dlords;
-mod dlords_reward_pool;
+mod reward_pool;
 mod velords;
 
 pub mod interfaces {
-    pub mod IDLordsRewardPool;
     pub mod IERC20;
+    pub mod IRewardPool;
     pub mod IVE;
 }
 

--- a/veLords/src/velords.cairo
+++ b/veLords/src/velords.cairo
@@ -41,8 +41,8 @@ impl PointDefault of Default<Point> {
 mod velords {
     use core::cmp::{min, max};
     use core::num::traits::Zero;
-    use lordship::interfaces::IDLordsRewardPool::{IDLordsRewardPoolDispatcher, IDLordsRewardPoolDispatcherTrait};
     use lordship::interfaces::IERC20::{IERC20, IERC20Dispatcher, IERC20DispatcherTrait};
+    use lordship::interfaces::IRewardPool::{IRewardPoolDispatcher, IRewardPoolDispatcherTrait};
     use lordship::interfaces::IVE::IVE;
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::upgrades::UpgradeableComponent;
@@ -77,7 +77,7 @@ mod velords {
         #[substorage(v0)]
         upgradeable: UpgradeableComponent::Storage,
         // pool for early exit penalties
-        reward_pool: IDLordsRewardPoolDispatcher,
+        reward_pool: IRewardPoolDispatcher,
         // stores total amount of LORDS locked
         supply: u128,
         // storing Lock details for an address
@@ -417,7 +417,7 @@ mod velords {
 
         fn set_reward_pool(ref self: ContractState, reward_pool: ContractAddress) {
             self.ownable.assert_only_owner();
-            self.reward_pool.write(IDLordsRewardPoolDispatcher { contract_address: reward_pool });
+            self.reward_pool.write(IRewardPoolDispatcher { contract_address: reward_pool });
         }
     }
 


### PR DESCRIPTION
Making the reward pool generic.

The `dlords_reward_pool` was based of Yearn's [`dYFIRewardPool`](https://github.com/yearn/veYFI/blob/master/contracts/dYFIRewardPool.vy) and it workes well when a `dToken` is the reward token. For the `veToken`, Yearn has [`RewardPool`](https://github.com/yearn/veYFI/blob/master/contracts/RewardPool.vy). Both contracts are almost the same.

This PR unifies those two contracts into a single one - `reward_pool.cairo`. We can deploy one with `LORDS` as the `reward_token` and another one with `dLORDS` as well when necessary.

The difference between this `reward_pool` and Yearn's `RewardPool` is that the latter has support for "relocking" when claiming rewards, but this is not necessary on Starknet - the functionality can be emulated by a carefully crafter multicall.

Q:
* should I use the same access control as in stREALMS for consistency? veLORDS use a single ownable admin that can also upgrade, there's no UPGRADER role. But looking at the deploy script of stREALMS, the admin and upgrader are the same 🧐 
* should I create a deploy script, similar to the one in stREALMS?