### PR TITLE
security-fix: force transfer to bridge before burn

### DIFF
--- a/stRealms/src/contracts/strealm.cairo
+++ b/stRealms/src/contracts/strealm.cairo
@@ -299,7 +299,14 @@ mod StRealm {
     #[abi(embed_v0)]
     impl ERC721MinterBurnerImpl of IERC721MinterBurner<ContractState> {
         fn burn(ref self: ContractState, token_id: u256) {
+            // only allow the bridge call the burn function
             self.access_control.assert_only_role(MINTER_ROLE);
+
+            // ensure the token was received by the bridge
+            let burner = starknet::get_caller_address();
+            let owner = self.owner_of(token_id);
+            assert!(burner == owner, "StRealm: burner not owner");
+
             self.erc721._burn(token_id);
         }
 
@@ -309,6 +316,7 @@ mod StRealm {
             token_id: u256,
             data: Span<felt252>,
         ) {
+            // only allow the bridge call the mint function
             self.access_control.assert_only_role(MINTER_ROLE);
             self.erc721._safe_mint(recipient, token_id, data);
         }


### PR DESCRIPTION
- Previously, the bridge had full permission to mint and burn tokens. it was in the bridge's cairo contract that we checked to see that the person bridging back to l1 was the owner of the token or was approved to spend it.

- The security implication of that was that, if the bridge's admin account got compromised, and they upgraded the contract to a malicious one,  OR if there was a bug in the bridge contract that allowed anyone to bridge any token to l1, the bridge could theoretically bridge back any tokens.

- now, by switching to the pattern where the owner must `set_approval` to the bridge contract to spend token and bridge back to l1, we minimise risk