### PR TITLE
fix: withdrawal calculation bug

### DIFF
--- a/veLords/src/tests/common.cairo
+++ b/veLords/src/tests/common.cairo
@@ -24,6 +24,10 @@ pub fn velords_owner() -> ContractAddress {
     contract_address_const::<'velords owner'>()
 }
 
+pub fn reward_pool_owner() -> ContractAddress {
+    contract_address_const::<'reward pool owner'>()
+}
+
 pub fn blobert() -> ContractAddress {
     contract_address_const::<'blobert'>()
 }
@@ -69,9 +73,11 @@ pub fn deploy_velords() -> ContractAddress {
     cls.deploy(@calldata).expect('velords deploy failed')
 }
 
-pub fn deploy_reward_pool(velords: ContractAddress, dlords: ContractAddress) -> ContractAddress {
-    let cls = declare("dlords_reward_pool");
-    let calldata: Array<felt252> = array![velords.into(), dlords.into(), get_block_timestamp().into()];
+pub fn deploy_reward_pool(velords: ContractAddress, reward_token: ContractAddress) -> ContractAddress {
+    let cls = declare("reward_pool");
+    let calldata: Array<felt252> = array![
+        reward_pool_owner().into(), velords.into(), reward_token.into(), get_block_timestamp().into()
+    ];
     cls.deploy(@calldata).expect('reward pool deploy failed')
 }
 
@@ -80,8 +86,7 @@ pub fn velords_setup() -> (IVEDispatcher, IERC20Dispatcher) {
 
     let lords: ContractAddress = deploy_lords();
     let velords: ContractAddress = deploy_velords();
-    let dlords: ContractAddress = deploy_dlords();
-    let reward_pool: ContractAddress = deploy_reward_pool(velords, dlords);
+    let reward_pool: ContractAddress = deploy_reward_pool(velords, lords);
 
     start_prank(CheatTarget::One(velords), velords_owner());
     IVEDispatcher { contract_address: velords }.set_reward_pool(reward_pool);

--- a/veLords/src/velords.cairo
+++ b/veLords/src/velords.cairo
@@ -555,7 +555,8 @@ mod velords {
                 last_point.slope = max(0, last_point.slope); // this shouldn't happen
                 last_checkpoint = t_i;
                 last_point.ts = t_i;
-                last_point.block = initial_last_point.block + block_slope * (t_i - initial_last_point.ts) / SCALE_U64;
+                last_point.block = initial_last_point.block
+                    + ((block_slope * (t_i - initial_last_point.ts)) / SCALE_U64);
                 epoch += 1;
 
                 if t_i < now {

--- a/veLords/src/velords.cairo
+++ b/veLords/src/velords.cairo
@@ -54,7 +54,8 @@ mod velords {
     use super::{Lock, Point};
 
     const LORDS_TOKEN: felt252 = 0x124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49;
-    const SCALE: u64 = 1000000000000000000; // 10 ** 18
+    const SCALE: u128 = 1000000000000000000; // 10 ** 18
+    const SCALE_U64: u64 = 1000000000000000000; // optimization
     const WEEK: u64 = 3600 * 24 * 7;
     const MAX_LOCK_DURATION: u64 = 4 * 365 * 86400; // 4 years
     const MAX_N_WEEKS: u64 = 210;
@@ -386,9 +387,10 @@ mod velords {
 
             let now: u64 = get_block_timestamp();
             let penalty: u128 = if locked.end_time > now {
-                let time_left: u64 = locked.end_time - now;
-                let penalty_ratio: u128 = min((time_left * SCALE / MAX_LOCK_DURATION).into(), MAX_PENALTY_RATIO);
-                locked.amount * penalty_ratio / SCALE.into()
+                let time_left: u128 = (locked.end_time - now).into();
+                let penalty_ratio: u128 = min((time_left * SCALE / MAX_LOCK_DURATION.into()), MAX_PENALTY_RATIO);
+                let amount: u256 = locked.amount.into(); // scaling up to u256 to prevent mul_overflow
+                (amount * penalty_ratio.into() / SCALE.into()).try_into().expect('penalty overflow')
             } else {
                 0
             };
@@ -539,7 +541,8 @@ mod velords {
             let initial_last_point: Point = last_point;
             let mut block_slope: u64 = 0; // dblock/dt
             if now > last_checkpoint {
-                block_slope = SCALE * (block - last_point.block) / (now - last_checkpoint);
+                let slope: u128 = (SCALE * (block - last_point.block).into()) / (now - last_checkpoint).into();
+                block_slope = slope.try_into().expect('block slope overflow');
             }
 
             // apply weekly slope changes and record weekly global snapshots
@@ -552,7 +555,7 @@ mod velords {
                 last_point.slope = max(0, last_point.slope); // this shouldn't happen
                 last_checkpoint = t_i;
                 last_point.ts = t_i;
-                last_point.block = initial_last_point.block + block_slope * (t_i - initial_last_point.ts) / SCALE;
+                last_point.block = initial_last_point.block + block_slope * (t_i - initial_last_point.ts) / SCALE_U64;
                 epoch += 1;
 
                 if t_i < now {


### PR DESCRIPTION
Due to using `u64` when doing internal calculations, a call to veLORDS `withdrawal` would result in `u64_mul Overflow`. This PR fixes that by using containers that can handle the necessary scale.

Also adding 2 tests of withdrawal functionality and some minor touch ups.

It should be possible to only upgrade the deployed contract after this new one is declared.