### PR TITLE
fix: claim bug

### DIFF
--- a/veLords/src/lib.cairo
+++ b/veLords/src/lib.cairo
@@ -16,5 +16,6 @@ pub mod mocks {
 #[cfg(test)]
 mod tests {
     pub mod common;
+    mod test_reward_pool;
     mod test_velords;
 }

--- a/veLords/src/reward_pool.cairo
+++ b/veLords/src/reward_pool.cairo
@@ -19,7 +19,7 @@ mod reward_pool {
     const DAY: u64 = 3600 * 24;
     const WEEK: u64 = DAY * 7;
     const TOKEN_CHECKPOINT_DEADLINE: u64 = DAY;
-    const ITERATION_LIMIT: u32 = 200;
+    const ITERATION_LIMIT: u32 = 10_000;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);

--- a/veLords/src/reward_pool.cairo
+++ b/veLords/src/reward_pool.cairo
@@ -263,6 +263,7 @@ mod reward_pool {
 
                 t = next_week;
                 this_week = next_week;
+                i += 1;
             };
 
             self.emit(CheckpointToken { time: now, tokens: to_distribute })
@@ -294,6 +295,7 @@ mod reward_pool {
                 self.ve_supply.write(t, ve_supply.into());
 
                 t += WEEK;
+                i += 1;
             };
 
             self.time_cursor.write(t);
@@ -334,6 +336,7 @@ mod reward_pool {
                 }
                 to_distribute += balance_of * self.tokens_per_week.read(week_cursor) / self.ve_supply.read(week_cursor);
                 week_cursor += WEEK;
+                i += 1;
             };
 
             self.time_cursor_of.write(recipient, week_cursor);

--- a/veLords/src/reward_pool.cairo
+++ b/veLords/src/reward_pool.cairo
@@ -19,7 +19,7 @@ mod reward_pool {
     const DAY: u64 = 3600 * 24;
     const WEEK: u64 = DAY * 7;
     const TOKEN_CHECKPOINT_DEADLINE: u64 = DAY;
-    const ITERATION_LIMIT: u32 = 10_000;
+    const ITERATION_LIMIT: u32 = 500;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);

--- a/veLords/src/tests/common.cairo
+++ b/veLords/src/tests/common.cairo
@@ -116,6 +116,17 @@ pub fn setup_for_blobert(lords: ContractAddress, velords: ContractAddress) {
     stop_prank(CheatTarget::One(lords));
 }
 
+pub fn setup_for_loaf(lords: ContractAddress, velords: ContractAddress) {
+    // give loaf 10M LORDS
+    let amount: u256 = ONE * 10_000_000; // 10M LORDS
+    fund_lords(loaf(), Option::Some(amount));
+
+    // loaf allows veLords contract to use its LORDS
+    start_prank(CheatTarget::One(lords), loaf());
+    IERC20Dispatcher { contract_address: lords }.approve(velords, amount);
+    stop_prank(CheatTarget::One(lords));
+}
+
 pub fn floor_to_week(ts: u64) -> u64 {
     (ts / WEEK) * WEEK
 }

--- a/veLords/src/tests/test_reward_pool.cairo
+++ b/veLords/src/tests/test_reward_pool.cairo
@@ -1,0 +1,57 @@
+use lordship::interfaces::IERC20::{IERC20Dispatcher, IERC20DispatcherTrait};
+use lordship::interfaces::IRewardPool::{IRewardPoolDispatcher, IRewardPoolDispatcherTrait};
+use lordship::interfaces::IVE::IVEDispatcherTrait;
+use lordship::tests::common;
+use snforge_std::{start_prank, start_warp, stop_prank, CheatTarget};
+use starknet::{ContractAddress, get_block_timestamp, get_contract_address};
+
+#[test]
+fn test_reward_pool_claim_pass() {
+    let (velords, lords) = common::velords_setup();
+    let reward_pool = IRewardPoolDispatcher { contract_address: velords.get_reward_pool() };
+    let blobert: ContractAddress = common::blobert();
+    common::setup_for_blobert(lords.contract_address, velords.contract_address);
+    let loaf: ContractAddress = common::loaf();
+    common::setup_for_loaf(lords.contract_address, velords.contract_address);
+
+    let blobert_lock_amount: u256 = 2_000_000 * common::ONE;
+    let loaf_lock_amount: u256 = 1_000_000 * common::ONE;
+    let now = get_block_timestamp();
+    let unlock_time: u64 = now + 4 * common::YEAR;
+
+    // blobert locks 2M LORDS for 4 years
+    start_prank(CheatTarget::One(velords.contract_address), blobert);
+    velords.manage_lock(blobert_lock_amount, unlock_time, blobert);
+
+    // loaf locks 1M LORDS for 4 years
+    start_prank(CheatTarget::One(velords.contract_address), loaf);
+    velords.manage_lock(loaf_lock_amount, unlock_time, loaf);
+
+    // simulate rewards going to the reward pool
+    let this = get_contract_address();
+    start_prank(CheatTarget::All, this);
+    let rewards: u256 = 500_000 * common::ONE;
+    common::fund_lords(this, Option::Some(rewards));
+    lords.approve(reward_pool.contract_address, rewards);
+
+    start_warp(CheatTarget::All, now + common::DAY * 30);
+    velords.checkpoint();
+    reward_pool.checkpoint_total_supply();
+    reward_pool.burn(rewards);
+
+    start_warp(CheatTarget::All, now + common::DAY * 60);
+
+    // loaf claims rewards
+    start_prank(CheatTarget::One(reward_pool.contract_address), loaf);
+    let loaf_rewards = reward_pool.claim(loaf);
+    common::assert_approx(loaf_rewards, rewards / 3, common::ONE * 10, "loaf rewards mismatch");
+
+    // loaf claims blobert's rewards (tests claiming on behalf of another account)
+    let blobert_rewards = reward_pool.claim(blobert);
+    common::assert_approx(blobert_rewards, rewards * 2 / 3, common::ONE * 10, "blobert rewards mismatch");
+
+    // all rewards claimed
+    common::assert_approx(loaf_rewards + blobert_rewards, rewards, common::ONE * 10, "total rewards mismatch");
+    let reward_pool_balance = lords.balance_of(reward_pool.contract_address);
+    common::assert_approx(reward_pool_balance, 0, common::ONE * 10, "reward pool balance mismatch");
+}

--- a/veLords/src/tests/test_velords.cairo
+++ b/veLords/src/tests/test_velords.cairo
@@ -469,8 +469,8 @@ fn test_locked_balance_progression() {
 
     assert_eq!(velords_token.balance_of(blobert), 0, "blobert's veLORDS balance mismatch after expiry");
 }
-// test other public fns
-// test withdrawal - interacts with reward pool
+
+// TODO: test other public fns
 
 #[test]
 fn test_withdrawal_after_lock_expiry_pass() {

--- a/veLords/src/velords.cairo
+++ b/veLords/src/velords.cairo
@@ -555,7 +555,8 @@ mod velords {
                 last_checkpoint = t_i;
                 last_point.ts = t_i;
                 // calculating block in u128 to prevent overflow
-                let blk: u128 = initial_last_point.block.into() + ((Into::<u64, u128>::into(block_slope) * (t_i - initial_last_point.ts).into()) / SCALE);
+                let blk: u128 = initial_last_point.block.into()
+                    + ((Into::<u64, u128>::into(block_slope) * (t_i - initial_last_point.ts).into()) / SCALE);
                 last_point.block = blk.try_into().expect('block overflow');
                 epoch += 1;
 

--- a/veLords/src/velords.cairo
+++ b/veLords/src/velords.cairo
@@ -55,7 +55,6 @@ mod velords {
 
     const LORDS_TOKEN: felt252 = 0x124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49;
     const SCALE: u128 = 1000000000000000000; // 10 ** 18
-    const SCALE_U64: u64 = 1000000000000000000; // optimization
     const WEEK: u64 = 3600 * 24 * 7;
     const MAX_LOCK_DURATION: u64 = 4 * 365 * 86400; // 4 years
     const MAX_N_WEEKS: u64 = 210;
@@ -555,8 +554,9 @@ mod velords {
                 last_point.slope = max(0, last_point.slope); // this shouldn't happen
                 last_checkpoint = t_i;
                 last_point.ts = t_i;
-                last_point.block = initial_last_point.block
-                    + ((block_slope * (t_i - initial_last_point.ts)) / SCALE_U64);
+                // calculating block in u128 to prevent overflow
+                let blk: u128 = initial_last_point.block.into() + ((Into::<u64, u128>::into(block_slope) * (t_i - initial_last_point.ts).into()) / SCALE);
+                last_point.block = blk.try_into().expect('block overflow');
                 epoch += 1;
 
                 if t_i < now {


### PR DESCRIPTION
Fixes a bug in the `claim` function where the iteration counter was not incremented, potentially leading to an out of gas error - though I don't think it would happen, because the calculations are cheap and Starknet has a huge step limit. Due to that, the PR is also raising the iteration limit massively.

Also adding a `claim()` test.